### PR TITLE
Test Racket 9.0 and Parbench installation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -30,8 +30,12 @@ fi
 if [ -x "$RACKET_DIR/bin/racket" ]; then
   export PATH="$RACKET_DIR/bin:$PATH"
 
+  # Persist PATH for future shell invocations
   if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     echo "export PATH=\"$RACKET_DIR/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  elif ! grep -q "$RACKET_DIR/bin" ~/.bashrc 2>/dev/null; then
+    # Fallback: add to .bashrc if CLAUDE_ENV_FILE not available
+    echo "export PATH=\"$RACKET_DIR/bin:\$PATH\"" >> ~/.bashrc
   fi
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "./.claude/hooks/session-start.sh"
           }
         ]
       }


### PR DESCRIPTION
- Use relative path in settings.json since $CLAUDE_PROJECT_DIR is not set
- Add fallback to ~/.bashrc when CLAUDE_ENV_FILE is not available